### PR TITLE
Add support for SUPEE-11155 and CE-1.9.4.2

### DIFF
--- a/app/code/community/Uni/Fileuploader/Model/Wysiwyg/Config.php
+++ b/app/code/community/Uni/Fileuploader/Model/Wysiwyg/Config.php
@@ -30,7 +30,8 @@ class Uni_Fileuploader_Model_Wysiwyg_Config extends Mage_Cms_Model_Wysiwyg_Confi
             'popup_css' => Mage::getBaseUrl('js') . 'mage/adminhtml/wysiwyg/tiny_mce/themes/advanced/skins/default/dialog.css',
             'content_css' => Mage::getBaseUrl('js') . 'mage/adminhtml/wysiwyg/tiny_mce/themes/advanced/skins/default/content.css',
             'width' => '100%',
-            'plugins' => array()
+            'plugins' => array(),
+            'media_disable_flash' => Mage::helper('cms')->isSwfDisabled()
         ));
 
         $config->setData('directives_url_quoted', preg_quote($config->getData('directives_url')));


### PR DESCRIPTION
This PR applies the changes to Mage_Cms_Model_Wysiwyg_Config::getConfig from SUPEE-11155 and CE-1.9.4.2 to the overridden version of the method.